### PR TITLE
fix: bad bounding box placement due to uncentered widget

### DIFF
--- a/lib/video/video.dart
+++ b/lib/video/video.dart
@@ -1,8 +1,8 @@
 export 'cubit/video_cubit.dart';
 export 'helpers/nearest_value_iterable.dart';
 export 'view/video_page.dart';
-export 'widgets/ball_detections.dart';
 export 'widgets/bounding_boxes_overlay.dart';
+export 'widgets/box_detections.dart';
 export 'widgets/fade_out.dart';
 export 'widgets/info_overlay.dart';
 export 'widgets/metadata_popup.dart';

--- a/lib/video/view/video_page.dart
+++ b/lib/video/view/video_page.dart
@@ -68,7 +68,7 @@ class _VideoViewState extends State<VideoView> {
               fit: StackFit.expand,
               children: [
                 Video(controller: cubit.controller),
-                const BallDetections(),
+                const BoxDetections(),
                 const TurnActionWidget(),
                 const ZoomAdjustmentWidget(),
               ],

--- a/lib/video/widgets/box_detections.dart
+++ b/lib/video/widgets/box_detections.dart
@@ -3,8 +3,8 @@ import 'package:ai_recording_visualizer/video/widgets/bounding_boxes_overlay.dar
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class BallDetections extends StatelessWidget {
-  const BallDetections({super.key});
+class BoxDetections extends StatelessWidget {
+  const BoxDetections({super.key});
 
   static Color hoopColor = Colors.red;
   static Color ballColor = Colors.yellow;
@@ -34,9 +34,11 @@ class BallDetections extends StatelessWidget {
               return BoundingBoxesOverlay(detections);
             }
 
-            return AspectRatio(
-              aspectRatio: aspectRatio,
-              child: BoundingBoxesOverlay(detections),
+            return Center(
+              child: AspectRatio(
+                aspectRatio: aspectRatio,
+                child: BoundingBoxesOverlay(detections),
+              ),
             );
           },
         );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Centers the AspectRatio widget with bounding boxes

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
